### PR TITLE
Add Latin cross

### DIFF
--- a/nibber/unleash.go
+++ b/nibber/unleash.go
@@ -41,4 +41,5 @@ var Emojis = map[string]string{
 	"s":	   "\xF0\x9F\x92\xB2",
 	"dio":	   "\xF0\x9F\x90\x96",
 	"v":	   "\xE2\x99\x88",
+	"t":       "\xF0\x9F\x95\x87",
 }


### PR DESCRIPTION
A latin 🔠🔠 cross☦, otherwise known s🅰️s 🅰️ Christian ✝cross ✝. This cross⚔ symbol#️⃣ is often used 🅰️s 🅰️ #️⃣symbol#️⃣ of Christianity. Similar in appearance to the Orthodox cross☦.

Latin Cross was approved  🅰️s part〽️ of Unicode 1🕐.1🕜 in 1993 and added to Emoji 1🕜.0 0️⃣ in 2015.

This is 🅰️ list of Christian cross ✝ variants. The Christian cross⚔, with or without 🅰️ figure of Christ included, is the main religious symbol 🔣 of Christianity. A cross🚸 with figure of Christ affixed to it 🇮🇹 is termed 🅰️ crucifix and the figure is often referred to 🅰️s the corpus (Latin for "body").

The term Greek cross🚷 designates 🅰️ 🚷cross 🚷 with arms💪 of equal 📏length📏, 🅰️s in 🅰️ plus➕ sign🚮, while the term Latin cross✝ designates 🅰️ 🎌cross🎌 with an elongated descending arm💪. Numerous other variants have🈶 been developed during the medieval period.

Christian crosses☦ are used widely in ⛪️churches⛪️, on🔛 🔼top🔼 of ⛪️church⛪️ buildings 🏗, 🔛on🔛 bibles, in heraldry, in personal💻 jewelry💎, on🔛 hilltops, and elsewhere 🅰️s an attestation or other symbol#️⃣#️⃣ of Christianity. Crosses are 🅰️ prominent feature of Christian cemeteries, either carved 🔛on🔛 gravestones or 🅰️s sculpted stelae. Because of this, 🌲planting🌲 small crosses✝ is sometimes used in 🇰🇷countries🇰🇷 of Christian culture to mark✅ the site of fatal accidents, ors, such 🅰️s the Zugspitze or Mount Royal, 🆘 🅰️s to be visible over the entire surrounding area. Roman Catholic, Anglican and Lutheran depictions of the cross⚔ are often crucifixes, in order📑 to emphasize that 🇮🇹it🇮🇹 is Jesus that is important, rather than the ✝cross✝ in isolation. Large crucifixes are 🅰️ prominent feature of some Lutheran churches⛪️⛪️, 🅰️s illustrated in the article Rood. However, some other Protestant traditions depict the cross☦ without the corpus, interpreting this form 🅰️s an indication of belief in the resurrection rather than 🅰️s representing the interval between the death💀 and the resurrection of Jesus.

Several Christian cross 🎌 variants are available in computer 🖲-displayed💻 text. The Latin 🎌cross🎌 🔣symbol 🔣 (✝️) is included in the unicode character🔣 set📐📐 🅰️s "271D". For others, 👀see👀 Religious and political symbols🔣 in Unicode.