### PR TITLE
Add snek

### DIFF
--- a/nibber/unleash.go
+++ b/nibber/unleash.go
@@ -59,4 +59,5 @@ var Emojis = map[string]string{
 	"peroni":  "\xF0\x9F\x8D\xBA",
 	"2peroni": "\xF0\x9F\x8D\xBB",
 	"sos":     "\xF0\x9F\x86\x98",
+	"snek":    "\xF0\x9F\x90\x8D",
 }


### PR DESCRIPTION
Snek refers to images of 🐍snakes🐍 with interior monologue captioning applied. The captions often use a🅰️ form of English that omits prepositions and/or spells 🆒words 🆒🆒 incorrectly; in ➕addition➕➕, the 🆕word🆕 “heck” is often substituted for profanity.

The 🆔word 🆔🆔 snek derives from This Is Snek, the popularity of which led to an entire subreddit, /r/snek, devoted to images of 🐍snakes🐍 with and without the additional interior monologue captioning. The 🕠earliest🕠 known example including interior monologue captioning (below) was 🏤posted🏤 to the Facebook community “Snek” on🔛🔛 October 16th, 2015. It 🉐obtained🉐 over 100💯 💚likes💚 and 20 shares in 5🕠 months🈷️.