### PR TITLE
Multiple spaces between words

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Usage of nibberbot:
     	required, domain associated to the TLS cert+key and the server where this bot will be running
   -key string
     	required, TLS key path
+  -numspaces int
+    	number of spaces between each word (default 1)
   -port string
     	port to run on, must be 443, 80, 88, 8443 (default "88")
 ```

--- a/handleupdate.go
+++ b/handleupdate.go
@@ -13,15 +13,13 @@ func handleUpdate(update tgbotapi.Update, bot *tgbotapi.BotAPI) {
 	if update.InlineQuery != nil {
 		log.Printf("[INLINE] new query sent in by %s -> %s\n", update.InlineQuery.From.UserName, update.InlineQuery.Query)
 		payload := []interface{}{}
-		var normalMemeString string
 		memeStr := nibberInstance.Nibbering(update.InlineQuery.Query)
 		clappingMemeStr := strings.Replace(memeStr, " ", " "+nibber.Clap+" ", -1)
-
+		normalMemeString := memeStr
 		if numberOfSpaces > 1 {
 			normalMemeString = strings.Replace(memeStr, " ", fillingSpace, -1)
-		} else {
-			normalMemeString = memeStr
 		}
+
 		article := tgbotapi.NewInlineQueryResultArticle(update.InlineQuery.ID, suh, normalMemeString)
 		article.Description = normalMemeString
 		payload = append(payload, article)

--- a/handleupdate.go
+++ b/handleupdate.go
@@ -13,11 +13,17 @@ func handleUpdate(update tgbotapi.Update, bot *tgbotapi.BotAPI) {
 	if update.InlineQuery != nil {
 		log.Printf("[INLINE] new query sent in by %s -> %s\n", update.InlineQuery.From.UserName, update.InlineQuery.Query)
 		payload := []interface{}{}
+		var normalMemeString string
 		memeStr := nibberInstance.Nibbering(update.InlineQuery.Query)
 		clappingMemeStr := strings.Replace(memeStr, " ", " "+nibber.Clap+" ", -1)
 
-		article := tgbotapi.NewInlineQueryResultArticle(update.InlineQuery.ID, suh, memeStr)
-		article.Description = memeStr
+		if numberOfSpaces > 1 {
+			normalMemeString = strings.Replace(memeStr, " ", fillingSpace, -1)
+		} else {
+			normalMemeString = memeStr
+		}
+		article := tgbotapi.NewInlineQueryResultArticle(update.InlineQuery.ID, suh, normalMemeString)
+		article.Description = normalMemeString
 		payload = append(payload, article)
 
 		clappingArticle := tgbotapi.NewInlineQueryResultArticle(update.InlineQuery.ID+"-clapping", clappingNibba, clappingMemeStr)

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/go-telegram-bot-api/telegram-bot-api"
 	"github.com/gsora/nibberbot/nibber"
@@ -24,10 +25,16 @@ var (
 	debug          bool
 	domain         string
 	port           string
+	numberOfSpaces int
+	fillingSpace   string
 )
 
 func main() {
 	setupParams()
+
+	if !(numberOfSpaces <= 0 || numberOfSpaces == 1) {
+		generateSpaces()
+	}
 
 	nibberInstance = nibber.NewNibber(nibber.Emojis)
 
@@ -65,12 +72,17 @@ func setupParams() {
 	flag.StringVar(&domain, "domain", "", "required, domain associated to the TLS cert+key and the server where this bot will be running")
 	flag.StringVar(&port, "port", "88", "port to run on, must be 443, 80, 88, 8443")
 	flag.BoolVar(&debug, "debug", false, "debug Telegram bot interactions")
+	flag.IntVar(&numberOfSpaces, "numspaces", 1, "number of spaces between each word")
 	flag.Parse()
 
 	if certPath == "" || keyPath == "" || apiKey == "" || domain == "" {
 		flag.Usage()
 		os.Exit(1)
 	}
+}
+
+func generateSpaces() {
+	fillingSpace = strings.Repeat(" ", numberOfSpaces)
 }
 
 func startServer() {


### PR DESCRIPTION
This commit adds the possibility to enable multiple spaces between each word that has been nibbered.

With the `-numspaces` parameter can be specified the number of spaces - defaults to 1.